### PR TITLE
fix: remove disabled certs from cache

### DIFF
--- a/pkg/controllers/clusterresource/keymanagementprovider_controller.go
+++ b/pkg/controllers/clusterresource/keymanagementprovider_controller.go
@@ -80,7 +80,7 @@ func (r *KeyManagementProviderReconciler) ReconcileWithType(ctx context.Context,
 		logger.Warn("Certificate Store already exists. Key management provider and certificate store should not be configured together. Please migrate to key management provider and delete certificate store.")
 	}
 
-	provider, err := cutils.SpecToKeyManagementProvider(keyManagementProvider.Spec.Parameters.Raw, keyManagementProvider.Spec.Type)
+	provider, err := cutils.SpecToKeyManagementProvider(keyManagementProvider.Spec.Parameters.Raw, keyManagementProvider.Spec.Type, resource)
 	if err != nil {
 		kmpErr := re.ErrorCodeKeyManagementProviderFailure.WithError(err).WithDetail("Failed to create key management provider from CR")
 

--- a/pkg/controllers/namespaceresource/keymanagementprovider_controller.go
+++ b/pkg/controllers/namespaceresource/keymanagementprovider_controller.go
@@ -79,7 +79,7 @@ func (r *KeyManagementProviderReconciler) ReconcileWithType(ctx context.Context,
 		logger.Warn("Certificate Store already exists. Key management provider and certificate store should not be configured together. Please migrate to key management provider and delete certificate store.")
 	}
 
-	provider, err := cutils.SpecToKeyManagementProvider(keyManagementProvider.Spec.Parameters.Raw, keyManagementProvider.Spec.Type)
+	provider, err := cutils.SpecToKeyManagementProvider(keyManagementProvider.Spec.Parameters.Raw, keyManagementProvider.Spec.Type, resource)
 	if err != nil {
 		kmpErr := re.ErrorCodeKeyManagementProviderFailure.WithError(err).WithDetail("Failed to create key management provider from CR")
 

--- a/pkg/controllers/utils/kmp.go
+++ b/pkg/controllers/utils/kmp.go
@@ -26,8 +26,8 @@ import (
 )
 
 // SpecToKeyManagementProvider creates KeyManagementProvider from  KeyManagementProviderSpec config
-func SpecToKeyManagementProvider(raw []byte, keyManagamentSystemName string) (kmp.KeyManagementProvider, error) {
-	kmProviderConfig, err := rawToKeyManagementProviderConfig(raw, keyManagamentSystemName)
+func SpecToKeyManagementProvider(raw []byte, keyManagamentSystemName, resource string) (kmp.KeyManagementProvider, error) {
+	kmProviderConfig, err := rawToKeyManagementProviderConfig(raw, keyManagamentSystemName, resource)
 	if err != nil {
 		return nil, err
 	}
@@ -42,7 +42,7 @@ func SpecToKeyManagementProvider(raw []byte, keyManagamentSystemName string) (km
 }
 
 // rawToKeyManagementProviderConfig converts raw json to KeyManagementProviderConfig
-func rawToKeyManagementProviderConfig(raw []byte, keyManagamentSystemName string) (config.KeyManagementProviderConfig, error) {
+func rawToKeyManagementProviderConfig(raw []byte, keyManagamentSystemName, resource string) (config.KeyManagementProviderConfig, error) {
 	pluginConfig := config.KeyManagementProviderConfig{}
 
 	if string(raw) == "" {
@@ -53,6 +53,7 @@ func rawToKeyManagementProviderConfig(raw []byte, keyManagamentSystemName string
 	}
 
 	pluginConfig[types.Type] = keyManagamentSystemName
+	pluginConfig[types.Resource] = resource
 
 	return pluginConfig, nil
 }

--- a/pkg/controllers/utils/kmp_test.go
+++ b/pkg/controllers/utils/kmp_test.go
@@ -26,6 +26,7 @@ func TestSpecToKeyManagementProviderProvider(t *testing.T) {
 		name      string
 		raw       []byte
 		kmpType   string
+		resource  string
 		expectErr bool
 	}{
 		{
@@ -36,19 +37,21 @@ func TestSpecToKeyManagementProviderProvider(t *testing.T) {
 			name:      "missing inline provider required fields",
 			raw:       []byte("{\"type\": \"inline\"}"),
 			kmpType:   "inline",
+			resource:  "test",
 			expectErr: true,
 		},
 		{
 			name:      "valid spec",
 			raw:       []byte(`{"type": "inline", "contentType": "certificate", "value": "-----BEGIN CERTIFICATE-----\nMIID2jCCAsKgAwIBAgIQXy2VqtlhSkiZKAGhsnkjbDANBgkqhkiG9w0BAQsFADBvMRswGQYDVQQD\nExJyYXRpZnkuZXhhbXBsZS5jb20xDzANBgNVBAsTBk15IE9yZzETMBEGA1UEChMKTXkgQ29tcGFu\neTEQMA4GA1UEBxMHUmVkbW9uZDELMAkGA1UECBMCV0ExCzAJBgNVBAYTAlVTMB4XDTIzMDIwMTIy\nNDUwMFoXDTI0MDIwMTIyNTUwMFowbzEbMBkGA1UEAxMScmF0aWZ5LmV4YW1wbGUuY29tMQ8wDQYD\nVQQLEwZNeSBPcmcxEzARBgNVBAoTCk15IENvbXBhbnkxEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNV\nBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAL10bM81\npPAyuraORABsOGS8M76Bi7Guwa3JlM1g2D8CuzSfSTaaT6apy9GsccxUvXd5cmiP1ffna5z+EFmc\nizFQh2aq9kWKWXDvKFXzpQuhyqD1HeVlRlF+V0AfZPvGt3VwUUjNycoUU44ctCWmcUQP/KShZev3\n6SOsJ9q7KLjxxQLsUc4mg55eZUThu8mGB8jugtjsnLUYvIWfHhyjVpGrGVrdkDMoMn+u33scOmrt\nsBljvq9WVo4T/VrTDuiOYlAJFMUae2Ptvo0go8XTN3OjLblKeiK4C+jMn9Dk33oGIT9pmX0vrDJV\nX56w/2SejC1AxCPchHaMuhlwMpftBGkCAwEAAaNyMHAwDgYDVR0PAQH/BAQDAgeAMAkGA1UdEwQC\nMAAwEwYDVR0lBAwwCgYIKwYBBQUHAwMwHwYDVR0jBBgwFoAU0eaKkZj+MS9jCp9Dg1zdv3v/aKww\nHQYDVR0OBBYEFNHmipGY/jEvYwqfQ4Nc3b97/2isMA0GCSqGSIb3DQEBCwUAA4IBAQBNDcmSBizF\nmpJlD8EgNcUCy5tz7W3+AAhEbA3vsHP4D/UyV3UgcESx+L+Nye5uDYtTVm3lQejs3erN2BjW+ds+\nXFnpU/pVimd0aYv6mJfOieRILBF4XFomjhrJOLI55oVwLN/AgX6kuC3CJY2NMyJKlTao9oZgpHhs\nLlxB/r0n9JnUoN0Gq93oc1+OLFjPI7gNuPXYOP1N46oKgEmAEmNkP1etFrEjFRgsdIFHksrmlOlD\nIed9RcQ087VLjmuymLgqMTFX34Q3j7XgN2ENwBSnkHotE9CcuGRW+NuiOeJalL8DBmFXXWwHTKLQ\nPp5g6m1yZXylLJaFLKz7tdMmO355\n-----END CERTIFICATE-----\n"}`),
 			kmpType:   "inline",
+			resource:  "test",
 			expectErr: false,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := SpecToKeyManagementProvider(tc.raw, tc.kmpType)
+			_, err := SpecToKeyManagementProvider(tc.raw, tc.kmpType, tc.resource)
 			if tc.expectErr != (err != nil) {
 				t.Fatalf("Expected error to be %t, got %t", tc.expectErr, err != nil)
 			}
@@ -60,6 +63,7 @@ func TestSpecToKeyManagementProviderProvider(t *testing.T) {
 func TestRawToKeyManagementProviderConfig(t *testing.T) {
 	testCases := []struct {
 		name         string
+		resource     string
 		raw          []byte
 		expectErr    bool
 		expectConfig config.KeyManagementProviderConfig
@@ -72,23 +76,26 @@ func TestRawToKeyManagementProviderConfig(t *testing.T) {
 		},
 		{
 			name:         "unmarshal failure",
+			resource:     "test",
 			raw:          []byte("invalid"),
 			expectErr:    true,
 			expectConfig: config.KeyManagementProviderConfig{},
 		},
 		{
 			name:      "valid Raw",
+			resource:  "test",
 			raw:       []byte("{\"type\": \"inline\"}"),
 			expectErr: false,
 			expectConfig: config.KeyManagementProviderConfig{
-				"type": "inline",
+				"type":     "inline",
+				"resource": "test",
 			},
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			config, err := rawToKeyManagementProviderConfig(tc.raw, "inline")
+			config, err := rawToKeyManagementProviderConfig(tc.raw, "inline", "test")
 
 			if tc.expectErr != (err != nil) {
 				t.Fatalf("Expected error to be %t, got %t", tc.expectErr, err != nil)

--- a/pkg/keymanagementprovider/keymanagementprovider.go
+++ b/pkg/keymanagementprovider/keymanagementprovider.go
@@ -157,6 +157,24 @@ func DeleteResourceFromMap(resource string) {
 	keyErrMap.Delete(resource)
 }
 
+// DeleteKeyFromMap deletes the keys from the map
+func DeleteCertificateFromMap(resource string, certKey KMPMapKey) {
+	if certs, ok := certificatesMap.Load(resource); ok {
+		if certMap, ok := certs.(map[KMPMapKey][]*x509.Certificate); ok {
+			delete(certMap, certKey)
+		}
+	}
+}
+
+// DeleteKeyFromMap deletes the keys from the map
+func DeleteKeyFromMap(resource string, key KMPMapKey) {
+	if keys, ok := keyMap.Load(resource); ok {
+		if keyMap, ok := keys.(map[KMPMapKey]PublicKey); ok {
+			delete(keyMap, key)
+		}
+	}
+}
+
 // FlattenKMPMap flattens the map of certificates fetched for a single key management provider resource and returns a single array
 func FlattenKMPMap(certMap map[KMPMapKey][]*x509.Certificate) []*x509.Certificate {
 	var items []*x509.Certificate

--- a/pkg/keymanagementprovider/types/types.go
+++ b/pkg/keymanagementprovider/types/types.go
@@ -19,5 +19,6 @@ const (
 	SpecVersion string = "0.1.0"
 	Version     string = "version"
 	Type        string = "type"
+	Resource    string = "resource"
 	Source      string = "source"
 )


### PR DESCRIPTION
# Description

## What this PR does / why we need it:
During a refresh of the KMP, if a certificate or key status changes to disabled it is removed from the cache.

## Which issue(s) this PR fixes *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #
- https://github.com/ratify-project/ratify/pull/1874#discussion_r1809307201
